### PR TITLE
feat: Implement per-distribution package filtering

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -229,7 +229,6 @@ jobs:
 
         # Copy new packages to distribution-specific pool
         if ls packages/*.deb 1> /dev/null 2>&1; then
-          mkdir -p "apt-repo/pool/$TARGET_DIST/main"
           cp packages/*.deb "apt-repo/pool/$TARGET_DIST/main/"
           echo "Copied $(ls packages/*.deb | wc -l) packages to $TARGET_DIST pool"
         else
@@ -323,14 +322,23 @@ jobs:
           echo "=== Targeted Mode: Updating $TARGET_DIST only ==="
           build_distribution "$TARGET_DIST" "$COMPONENT"
         else
-          echo "=== Full Rebuild Mode: Updating stable distributions only ==="
-          echo "(Unstable distributions require targeted updates from package repos)"
-          # Only build stable distributions in full rebuild mode
-          # Unstable distributions get packages from targeted updates when repos push to main
-          STABLE_DISTRIBUTIONS="stable bookworm-stable trixie-stable"
-          for dist in $STABLE_DISTRIBUTIONS; do
+          echo "=== Full Rebuild Mode ==="
+          echo "Packages downloaded from all repositories are in pool/stable/main/"
+          echo "Building all distributions (stable will have packages, others initially empty)"
+
+          # In full rebuild mode:
+          # - Downloaded packages are in pool/stable/main/ (Hat Labs products)
+          # - Build all distributions to ensure metadata exists
+          # - Only stable will have packages initially
+          # - Distribution-specific packages (bookworm/trixie) populate via targeted updates
+
+          for dist in ${{ steps.payload.outputs.all_distributions }}; do
             build_distribution "$dist" "main"
           done
+
+          echo ""
+          echo "Note: Distribution-specific packages (bookworm/trixie) are added via targeted"
+          echo "updates when package repositories build for those distributions."
         fi
 
         echo ""


### PR DESCRIPTION
## Summary

Implements per-distribution package filtering to ensure packages only appear in their intended distributions.

**Implements**: #11

## Changes

### Pool Structure

Changed from shared pool to distribution-specific pools:

**Before:**
```
pool/
└── main/
    └── [all packages]
```

**After:**
```
pool/
├── stable/main/
├── unstable/main/
├── bookworm-stable/main/
├── bookworm-unstable/main/
├── trixie-stable/main/
└── trixie-unstable/main/
```

### Workflow Changes

1. **Setup** - Create distribution-specific pool directories for all distributions
2. **Package Copying** - Copy packages to `pool/$TARGET_DIST/main/` instead of shared `pool/main/`
3. **Metadata Generation** - Scan `pool/$dist/` instead of `pool/` when generating Packages files

## Benefits

- ✅ Bookworm packages only in bookworm-* distributions
- ✅ Trixie packages only in trixie-* distributions  
- ✅ Hat Labs product packages only in stable/unstable
- ✅ No cross-distribution package pollution
- ✅ Prevents dependency conflicts from wrong-distribution packages

## Migration Strategy

This is a **breaking change** in the pool structure. The existing `pool/main/` will no longer be scanned.

**Options:**
1. **Clean rebuild** - Remove existing repository and rebuild from package releases
2. **Manual migration** - Move existing packages to appropriate distribution pools
3. **Automatic detection** - Determine package target distribution from metadata

**Recommendation:** Clean rebuild, since multi-distribution support is new and there are likely few/no packages in production yet.

## Testing Plan

- [ ] Verify pool directories created correctly
- [ ] Test package upload to specific distribution
- [ ] Confirm packages only appear in target distribution
- [ ] Test all 6 distributions
- [ ] Verify backward compatibility (stable/main still works)

## Dependencies

- Depends on #9 (merged)
- Should merge after #10 (web interface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)