### PR TITLE
feat(workflows): add manual package removal workflow

### DIFF
--- a/.github/workflows/remove-package.yml
+++ b/.github/workflows/remove-package.yml
@@ -108,14 +108,53 @@ jobs:
         echo "Generating Release file for $DIST..."
         cd "dists/$DIST"
 
+        # Set Suite, Codename, and Description based on distribution
+        case "$DIST" in
+          stable)
+            SUITE="stable"
+            CODENAME="stable"
+            DESCRIPTION="Hat Labs Stable APT Repository"
+            ;;
+          unstable)
+            SUITE="unstable"
+            CODENAME="unstable"
+            DESCRIPTION="Hat Labs Unstable APT Repository"
+            ;;
+          bookworm-stable)
+            SUITE="stable"
+            CODENAME="bookworm"
+            DESCRIPTION="Hat Labs Bookworm Stable APT Repository"
+            ;;
+          bookworm-unstable)
+            SUITE="unstable"
+            CODENAME="bookworm"
+            DESCRIPTION="Hat Labs Bookworm Unstable APT Repository"
+            ;;
+          trixie-stable)
+            SUITE="stable"
+            CODENAME="trixie"
+            DESCRIPTION="Hat Labs Trixie Stable APT Repository"
+            ;;
+          trixie-unstable)
+            SUITE="unstable"
+            CODENAME="trixie"
+            DESCRIPTION="Hat Labs Trixie Unstable APT Repository"
+            ;;
+          *)
+            SUITE="$DIST"
+            CODENAME="$DIST"
+            DESCRIPTION="Hat Labs APT Repository"
+            ;;
+        esac
+
         cat > Release <<EOF
 Origin: Hat Labs
 Label: Hat Labs
-Suite: $DIST
-Codename: $DIST
+Suite: $SUITE
+Codename: $CODENAME
 Architectures: arm64 all
 Components: main
-Description: Hat Labs APT Repository
+Description: $DESCRIPTION
 Date: $(date -Ru)
 EOF
 


### PR DESCRIPTION
## Summary

Adds a manually-triggered workflow for removing packages from specific distributions in the APT repository.

## Use Case

This workflow is needed to clean up packages that were:
- Published to the wrong distribution (e.g., `unstable` instead of `trixie-unstable`)
- Need to be yanked/removed from the repository
- Published with errors and need to be removed before republishing

## Features

**Manual Trigger with Inputs:**
- `package_name`: Name of package to remove (e.g., cockpit-apt)
- `distribution`: Target distribution (stable, unstable, trixie-unstable, etc.)
- `architecture`: Package architecture (all, arm64, amd64)

**Workflow Steps:**
1. ✅ Removes all matching .deb files from the distribution pool
2. ✅ Rebuilds repository metadata (Packages, Packages.gz)
3. ✅ Regenerates Release file with checksums
4. ✅ Re-signs the repository with GPG
5. ✅ Commits and pushes changes

## Usage

```
1. Go to Actions → Remove Package from APT Repository
2. Click "Run workflow"
3. Fill in:
   - Package name: cockpit-apt
   - Distribution: unstable
   - Architecture: all
4. Click "Run workflow"
```

## Example: Remove cockpit-apt from unstable

This will remove the `cockpit-apt` package that was incorrectly published to `unstable/main` (should have been `trixie-unstable/main`):

```
package_name: cockpit-apt
distribution: unstable
architecture: all
```

## Safety

- Only removes packages matching the exact name pattern
- Rebuilds metadata to keep repository consistent
- Creates a commit showing what was removed and by whom
- Can be run multiple times safely (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)