### PR TITLE
docs: Add workspace reference for agentic coding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,39 @@ APT repository infrastructure for Hat Labs packages and tools.
 
 **Branch Workflow:** Never push to main directly - always use feature branches and PRs.
 
+## Issue Creation & Implementation
+
+**MANDATORY:** All GitHub issues must require following `halos-distro/docs/IMPLEMENTATION_CHECKLIST.md` during implementation. Include this requirement in the issue body when creating issues.
+
+## Development Workflow
+
+**MANDATORY:** Follow `halos-distro/docs/DEVELOPMENT_WORKFLOW.md` for ALL implementations.
+
+**Standard Workflow for All Features:**
+
+1. **EXPLORE** - Read relevant code WITHOUT writing any code
+   - Use `Task tool with subagent_type=Explore` for complex navigation
+   - Reference relevant documentation
+2. **PLAN** - Create implementation approach
+   - Use `think hard` for planning
+   - Document the plan before coding
+3. **TEST** - Write tests FIRST (TDD)
+   - Write comprehensive tests
+   - Verify tests fail
+   - Commit tests
+4. **IMPLEMENT** - Code until tests pass
+   - Follow the plan
+   - Don't modify tests
+   - Iterate until all pass
+5. **VERIFY** - Check implementation quality
+   - Use subagents for verification
+   - Check for edge cases
+6. **COMMIT** to a feature branch
+7. **CREATE PR** and push to remote
+8. **WAIT** for CI checks
+9. **CHECK PR status** - verify tests pass, review feedback
+10. **ITERATE** if needed, then merge
+
 ## Repository Structure
 
 This repository maintains the Hat Labs APT repository at https://apt.hatlabs.fi.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Hat Labs APT repository
 
-This is the APT repository for Hat Labs. It contains packages and tools for use with our systems.
+This is the APT repository for Hat Labs. It contains packages and tools for use with our devices and with HaLOS (Hat Labs Operating System).
+
+To use this repository, follow the instructions at [apt.hatlabs.fi](https://apt.hatlabs.fi).
 
 ## Agentic Coding Setup (Claude Code, GitHub Copilot, etc.)
 


### PR DESCRIPTION
## Summary

Updates AGENTS.md and README.md to direct AI-assisted development to use the halos-distro workspace for full context across all repositories.

## Changes

- **AGENTS.md**: Created new file with workspace setup instructions and repository overview
- **README.md**: Added "Agentic Coding Setup" section

## Rationale

This follows the pattern established in cockpit-apt PR #51. By working from the halos-distro workspace, Claude Code and other AI assistants get access to:
- Complete workspace context across all repos
- Centralized development workflow documentation
- Implementation checklists and best practices

## References

- halos-distro/docs/HUMAN_DEVELOPMENT_GUIDANCE.md
- halos-distro/docs/IMPLEMENTATION_CHECKLIST.md
- halos-distro/docs/DEVELOPMENT_WORKFLOW.md
- cockpit-apt#51 (template for this change)