### PR TITLE
fix: correct heredoc syntax in remove-package workflow

### DIFF
--- a/.github/workflows/remove-package.yml
+++ b/.github/workflows/remove-package.yml
@@ -147,16 +147,16 @@ jobs:
             ;;
         esac
 
-        cat > Release <<EOF
-Origin: Hat Labs
-Label: Hat Labs
-Suite: $SUITE
-Codename: $CODENAME
-Architectures: arm64 all
-Components: main
-Description: $DESCRIPTION
-Date: $(date -Ru)
-EOF
+        cat > Release <<-EOF
+        Origin: Hat Labs
+        Label: Hat Labs
+        Suite: $SUITE
+        Codename: $CODENAME
+        Architectures: arm64 all
+        Components: main
+        Description: $DESCRIPTION
+        Date: $(date -Ru)
+        EOF
 
         # Add checksums using apt-ftparchive
         apt-ftparchive release . >> Release


### PR DESCRIPTION
## Problem

The remove-package.yml workflow had a YAML syntax error on line 159 that prevented it from running.

## Root Cause

In GitHub Actions workflows, when using heredocs within YAML `run:` blocks, the heredoc terminator must either:
1. Have NO indentation, OR
2. Use `<<-EOF` syntax (with hyphen) which allows the terminator to have leading whitespace

The original code used `<<EOF` but the terminator had 8 spaces of indentation, causing the YAML parser to fail.

## Solution

Changed to use `<<-EOF` (heredoc with leading whitespace stripping) and properly indented all content lines. This:
- Allows the EOF terminator to be properly indented with surrounding code
- Maintains code readability with consistent indentation
- Strips leading whitespace from the heredoc content (which is removed anyway by apt's Release file format)

## Changes

```diff
- cat > Release <<EOF
+ cat > Release <<-EOF
+ Origin: Hat Labs
+ ...
+ EOF
```

## Verification

The workflow YAML can now be parsed correctly by GitHub Actions without syntax errors.