### PR TITLE
fix: resolve YAML syntax error in workflow file

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -212,14 +212,14 @@ jobs:
                   mv "$temp_file" "$final_path"
 
                   # Store metadata for routing (used by later issues #30, #32)
-                  cat > "${final_path}.meta" <<EOF
-package=$package_name
-version=$actual_version
-architecture=$architecture
-distro=$pkg_distro
-component=$pkg_component
-original_filename=$name
-EOF
+                  {
+                    echo "package=$package_name"
+                    echo "version=$actual_version"
+                    echo "architecture=$architecture"
+                    echo "distro=$pkg_distro"
+                    echo "component=$pkg_component"
+                    echo "original_filename=$name"
+                  } > "${final_path}.meta"
 
                   echo "  Package: $package_name"
                   echo "  Version: $actual_version"


### PR DESCRIPTION
Fixes the workflow validation error:

```
Invalid workflow file: .github/workflows/update-repo.yml#L216
You have an error in your yaml syntax on line 216
```

## Problem

The heredoc syntax (`<<EOF`) in the metadata file creation was causing the YAML parser to misinterpret the heredoc content as YAML rather than shell script content.

## Solution

Replaced heredoc syntax with echo statements and command grouping:

**Before:**
```bash
cat > "${final_path}.meta" <<EOF
package=$package_name
version=$actual_version
...
EOF
```

**After:**
```bash
{
  echo "package=$package_name"
  echo "version=$actual_version"
  ...
} > "${final_path}.meta"
```

This maintains the same functionality while producing valid YAML syntax that the parser can handle correctly.