### PR TITLE
fix: source helper scripts in subshell for full rebuild mode

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -273,8 +273,13 @@ jobs:
             mkdir -p packages
 
             # Download packages for all repositories
+            # Note: source scripts again here because the pipe creates a subshell
+            # where the previously sourced variables are not available
             echo "${{ steps.discover.outputs.repos }}" | while IFS= read -r repo; do
               if [ -n "$repo" ]; then
+                # Re-source in subshell for access to SUPPORTED_DISTROS and functions
+                source scripts/suffix-parsing-functions.sh || { echo "❌ Failed to load suffix parsing functions"; exit 1; }
+                source scripts/routing-functions.sh || { echo "❌ Failed to load routing functions"; exit 1; }
                 download_from_repo "$repo" "$RELEASE_TAG"
               fi
             done


### PR DESCRIPTION
## Problem

The `update-repo` workflow was failing during the "Download packages" step with exit code 1.

The root cause: The workflow uses a pipe operator to read the list of repositories:
```bash
echo "$repos" | while IFS= read -r repo; do
  ...
done
```

This pipe creates a **subshell** where the previously sourced variables (like `SUPPORTED_DISTROS` from `routing-functions.sh`) are not available. When the routing logic tried to expand packages with `distro=any` to all supported distributions, it failed because the `SUPPORTED_DISTROS` array was empty.

## Solution

Re-source the helper scripts inside the subshell so that the functions and variables are available for both download and routing operations.

## Changes

- Re-source `suffix-parsing-functions.sh` and `routing-functions.sh` inside the while loop's subshell
- Added comment explaining why the re-sourcing is necessary

## Testing

This fix should allow the workflow to complete the "Download packages" step successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)