### PR TITLE
fix: handle dpkg-deb failures in package metadata extraction

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -185,10 +185,10 @@ jobs:
               if [ $? -eq 0 ]; then
                 echo "✓ Downloaded $name"
 
-                # Extract package metadata
-                actual_version=$(dpkg-deb --field "$temp_file" Version 2>/dev/null)
-                package_name=$(dpkg-deb --field "$temp_file" Package 2>/dev/null)
-                architecture=$(dpkg-deb --field "$temp_file" Architecture 2>/dev/null)
+                # Extract package metadata (using || true to prevent script exit on missing fields)
+                actual_version=$(dpkg-deb --field "$temp_file" Version 2>/dev/null || true)
+                package_name=$(dpkg-deb --field "$temp_file" Package 2>/dev/null || true)
+                architecture=$(dpkg-deb --field "$temp_file" Architecture 2>/dev/null || true)
 
                 if [ -n "$actual_version" ] && [ -n "$package_name" ] && [ -n "$architecture" ]; then
                   # Parse suffix from original filename
@@ -273,8 +273,13 @@ jobs:
             mkdir -p packages
 
             # Download packages for all repositories
+            # Note: source scripts again here because the pipe creates a subshell
+            # where the previously sourced variables are not available
             echo "${{ steps.discover.outputs.repos }}" | while IFS= read -r repo; do
               if [ -n "$repo" ]; then
+                # Re-source in subshell for access to SUPPORTED_DISTROS and functions
+                source scripts/suffix-parsing-functions.sh || { echo "❌ Failed to load suffix parsing functions"; exit 1; }
+                source scripts/routing-functions.sh || { echo "❌ Failed to load routing functions"; exit 1; }
                 download_from_repo "$repo" "$RELEASE_TAG"
               fi
             done


### PR DESCRIPTION
## Problem

The workflow was still failing in the "Download packages" step even after fixing the subshell variable scope issue.

The root cause: `dpkg-deb --field` can exit with non-zero status if a field is missing from a package or if there's an issue reading the file. When the script runs with `set -e` (fail on any error), this causes the entire script to exit without any error output, since stderr is redirected to `/dev/null`.

This explains why we see:
```
✓ Downloaded halpid-dbgsym_4.0.7_amd64.deb
##[error]Process completed with exit code 1.
```

The download succeeds but then dpkg-deb fails silently.

## Solution

Add `|| true` to dpkg-deb commands to gracefully handle failures. The subsequent check for empty variables (`if [ -n "$actual_version" ]...`) will naturally handle the case where metadata couldn't be extracted.

## Changes

- Updated dpkg-deb commands to use `|| true` for graceful failure handling
- Now packages with missing metadata fall back to keeping original filename
- No changes to overall script logic or behavior

## Testing

This should allow the workflow to complete the download phase by handling packages gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)