### PR TITLE
feat: default legacy packages to hatlabs component

### DIFF
--- a/scripts/suffix-parsing-functions.sh
+++ b/scripts/suffix-parsing-functions.sh
@@ -43,9 +43,11 @@ parse_package_suffix() {
     eval "$component_var=\"${BASH_REMATCH[2]}\""
     return 0
   else
-    # No suffix found - use defaults (backward compatibility)
+    # No suffix found - use defaults
+    # Temporary: default to hatlabs component to avoid breaking production stable/main
+    # Once all packages have proper distro+component suffixes, this will change to main
     eval "$distro_var=\"any\""
-    eval "$component_var=\"main\""
+    eval "$component_var=\"hatlabs\""
     return 1
   fi
 }

--- a/scripts/test-suffix-parsing.sh
+++ b/scripts/test-suffix-parsing.sh
@@ -86,7 +86,7 @@ assert_equals "main" "$component" "Component should be 'main'"
 test_case "No suffix - fallback to defaults"
 parse_package_suffix "old-package_1.0-1_all.deb" distro component
 assert_equals "any" "$distro" "Distro should fallback to 'any'"
-assert_equals "main" "$component" "Component should fallback to 'main'"
+assert_equals "hatlabs" "$component" "Component should fallback to 'hatlabs' (temporary, legacy packages)"
 
 # Test 5: Invalid distro - should warn and fallback
 test_case "Invalid distro - fallback"
@@ -106,7 +106,7 @@ assert_equals "invalid" "$component" "Should extract component even if invalid"
 test_case "Malformed suffix (single +) - fallback"
 parse_package_suffix "package_1.0-1_all+trixie.deb" distro component
 assert_equals "any" "$distro" "Should fallback to 'any'"
-assert_equals "main" "$component" "Should fallback to 'main'"
+assert_equals "hatlabs" "$component" "Should fallback to 'hatlabs'"
 
 # Test 8: Complex package name with dashes and numbers
 test_case "Complex package name"
@@ -165,7 +165,7 @@ fi
 test_case "Real package: halpid-dbgsym without suffix"
 parse_package_suffix "halpid-dbgsym_4.0.7_amd64.deb" distro component
 assert_equals "any" "$distro" "Should fallback to 'any' for package without suffix"
-assert_equals "main" "$component" "Should fallback to 'main' for package without suffix"
+assert_equals "hatlabs" "$component" "Should fallback to 'hatlabs' for legacy packages without suffix"
 
 # Test 15: Real package with suffix - ensures regex still works
 test_case "Real package with suffix: cockpit-apt"


### PR DESCRIPTION
## Problem

Legacy packages without distro+component suffix were defaulting to `distro=any, component=main`, which routed them to the production stable/main repository. This could cause issues during the multi-distribution implementation transition.

## Solution

Change the default component for legacy packages from `main` to `hatlabs`:
- Packages without suffix now route to: `distro=any, component=hatlabs`
- This expands to all distributions under the hatlabs component
- Keeps production stable/main clean during the transition

## Impact

Legacy packages (halpid, halpi2-firmware, etc.) will now appear in:
- ✅ trixie-stable/hatlabs, trixie-unstable/hatlabs
- ✅ bookworm-stable/hatlabs, bookworm-unstable/hatlabs
- ✅ stable/hatlabs, unstable/hatlabs
- ❌ NOT in stable/main (safe for production)

## Testing

All 15 unit tests pass with updated assertions for the new default.

## Future

Once packages are properly updated with distro+component suffixes in their release filenames, this default can be reverted to `main` as part of the production rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)