### PR TITLE
feat: add armhf (32-bit ARM) architecture support

### DIFF
--- a/.github/workflows/remove-package.yml
+++ b/.github/workflows/remove-package.yml
@@ -24,9 +24,10 @@ on:
         default: 'all'
         type: choice
         options:
-          # Only 'all' and 'arm64' are supported. Do not add 'amd64' unless repository metadata generation and scanning are updated to support it.
+          # Only 'all', 'arm64', and 'armhf' are supported. Do not add 'amd64' unless repository metadata generation and scanning are updated to support it.
           - all
           - arm64
+          - armhf
 
 jobs:
   remove-package:
@@ -95,7 +96,7 @@ jobs:
         cd apt-repo
 
         # Generate Packages file
-        for arch in arm64 all; do
+        for arch in arm64 armhf all; do
           ARCH_DIR="dists/$DIST/main/binary-$arch"
           if [ -d "$ARCH_DIR" ]; then
             echo "Generating Packages file for $arch..."
@@ -152,7 +153,7 @@ jobs:
         Label: Hat Labs
         Suite: $SUITE
         Codename: $CODENAME
-        Architectures: arm64 all
+        Architectures: arm64 armhf all
         Components: main
         Description: $DESCRIPTION
         Date: $(date -Ru)

--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -147,6 +147,7 @@ jobs:
             echo "Creating distribution: $dist"
             mkdir -p "apt-repo/pool/$dist/main"
             mkdir -p "apt-repo/dists/$dist/main/binary-arm64"
+            mkdir -p "apt-repo/dists/$dist/main/binary-armhf"
             mkdir -p "apt-repo/dists/$dist/main/binary-all"
           done
         else
@@ -159,6 +160,7 @@ jobs:
           # Ensure target distribution directories exist (won't overwrite existing)
           mkdir -p "apt-repo/pool/$TARGET_DIST/$COMPONENT"
           mkdir -p "apt-repo/dists/$TARGET_DIST/$COMPONENT/binary-arm64"
+          mkdir -p "apt-repo/dists/$TARGET_DIST/$COMPONENT/binary-armhf"
           mkdir -p "apt-repo/dists/$TARGET_DIST/$COMPONENT/binary-all"
 
           echo "✓ Ensured $TARGET_DIST/$COMPONENT directories exist"
@@ -472,6 +474,7 @@ jobs:
 
           # Ensure directories exist
           mkdir -p "$comp_path/binary-arm64"
+          mkdir -p "$comp_path/binary-armhf"
           mkdir -p "$comp_path/binary-all"
 
           # Generate Packages files for each architecture
@@ -480,6 +483,10 @@ jobs:
           # ARM64 packages - scan only this component's pool
           dpkg-scanpackages -a arm64 "$pool_path" /dev/null > "$comp_path/binary-arm64/Packages" 2>/dev/null || touch "$comp_path/binary-arm64/Packages"
           gzip -kf "$comp_path/binary-arm64/Packages"
+
+          # ARMHF packages - scan only this component's pool
+          dpkg-scanpackages -a armhf "$pool_path" /dev/null > "$comp_path/binary-armhf/Packages" 2>/dev/null || touch "$comp_path/binary-armhf/Packages"
+          gzip -kf "$comp_path/binary-armhf/Packages"
 
           # Architecture-independent packages - scan only this component's pool
           dpkg-scanpackages -a all "$pool_path" /dev/null > "$comp_path/binary-all/Packages" 2>/dev/null || touch "$comp_path/binary-all/Packages"
@@ -500,7 +507,7 @@ jobs:
           # Only include known components (main, hatlabs) to prevent including temporary directories
           local components=""
           for comp in main hatlabs; do
-            if [ -f "$dist_path/$comp/binary-arm64/Packages" ] || [ -f "$dist_path/$comp/binary-all/Packages" ]; then
+            if [ -f "$dist_path/$comp/binary-arm64/Packages" ] || [ -f "$dist_path/$comp/binary-armhf/Packages" ] || [ -f "$dist_path/$comp/binary-all/Packages" ]; then
               components="$components $comp"
             fi
           done
@@ -547,7 +554,7 @@ jobs:
         Suite: $SUITE
         Codename: $CODENAME
         Version: 1.0
-        Architectures: arm64 all
+        Architectures: arm64 armhf all
         Components: $components
         Description: $DESC
         Date: $(date -Ru)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,6 +33,7 @@ apt-repo/
 │   ├── stable/             # Hat Labs product packages stable channel (legacy)
 │   │   └── main/
 │   │       ├── binary-arm64/
+│   │       ├── binary-armhf/
 │   │       └── binary-all/
 │   ├── unstable/           # Hat Labs product packages unstable channel (legacy)
 │   │   └── main/

--- a/docs/COMPONENT-STRUCTURE.md
+++ b/docs/COMPONENT-STRUCTURE.md
@@ -67,12 +67,18 @@ apt-repo/dists/trixie-stable/
 │   ├── binary-arm64/
 │   │   ├── Packages          # Packages in main component (arm64)
 │   │   └── Packages.gz
+│   ├── binary-armhf/
+│   │   ├── Packages          # Packages in main component (armhf)
+│   │   └── Packages.gz
 │   └── binary-all/
 │       ├── Packages          # Packages in main component (all architectures)
 │       └── Packages.gz
 └── hatlabs/
     ├── binary-arm64/
     │   ├── Packages          # Packages in hatlabs component (arm64)
+    │   └── Packages.gz
+    ├── binary-armhf/
+    │   ├── Packages          # Packages in hatlabs component (armhf)
     │   └── Packages.gz
     └── binary-all/
         ├── Packages          # Packages in hatlabs component (all architectures)
@@ -88,13 +94,17 @@ apt-repo/dists/trixie-stable/
 Example Release file excerpt:
 ```
 Components: main hatlabs
-Architectures: arm64 all
+Architectures: arm64 armhf all
 
 MD5Sum:
  <hash> 1234 main/binary-arm64/Packages
  <hash> 2345 main/binary-arm64/Packages.gz
- <hash> 3456 hatlabs/binary-arm64/Packages
- <hash> 4567 hatlabs/binary-arm64/Packages.gz
+ <hash> 3456 main/binary-armhf/Packages
+ <hash> 4567 main/binary-armhf/Packages.gz
+ <hash> 5678 hatlabs/binary-arm64/Packages
+ <hash> 6789 hatlabs/binary-arm64/Packages.gz
+ <hash> 7890 hatlabs/binary-armhf/Packages
+ <hash> 8901 hatlabs/binary-armhf/Packages.gz
 ```
 
 ## Using Components in APT

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -193,7 +193,7 @@ The `stable/main` distribution must remain indefinitely to support existing HALP
 
 ### Architecture Support
 
-Current focus is on ARM architectures (arm64 only) and architecture-independent packages (all). x86_64 is not in scope.
+Current focus is on ARM architectures (arm64 and armhf) and architecture-independent packages (all). x86_64 is not in scope.
 
 ### Repository Signing
 

--- a/scripts/generate-index.py
+++ b/scripts/generate-index.py
@@ -18,7 +18,7 @@ import html
 # Constants
 REPO_URL = 'https://apt.hatlabs.fi'
 KEYRING_PATH = '/usr/share/keyrings/hatlabs.gpg'
-SUPPORTED_ARCHITECTURES = ['arm64', 'all']
+SUPPORTED_ARCHITECTURES = ['arm64', 'armhf', 'all']
 
 UNSTABLE_WARNING = '''
                 <div class="warning-box">
@@ -183,9 +183,10 @@ def get_preferred_architecture(arch1: str, arch2: str) -> str:
     """Return the preferred architecture for display purposes.
 
     Prefers more specific architectures (arm64, armhf) over generic ones (all).
+    arm64 is preferred over armhf for display purposes.
     """
     # Define preference order (higher index = higher priority)
-    preference = {'all': 0, 'arm64': 1}
+    preference = {'all': 0, 'armhf': 1, 'arm64': 2}
 
     pref1 = preference.get(arch1, 1)  # Default to middle priority
     pref2 = preference.get(arch2, 1)


### PR DESCRIPTION
## Summary

Adds armhf (32-bit ARM) architecture support to eliminate APT errors when users on 32-bit Raspberry Pi OS (armhf) systems use the repository.

## Problem

User reported this error when running `apt update`:
```
N: Skipping acquire of configured file 'main/binary-armhf/Packages' as repository 
   'https://apt.hatlabs.fi stable InRelease' doesn't support architecture 'armhf'
```

The repository only supported arm64 and all architectures, causing APT to skip armhf systems entirely.

## Solution

Add armhf architecture support across all repository infrastructure:

### Documentation Updates
- **SPEC.md**: Changed from "arm64 only" to "arm64 and armhf"
- **ARCHITECTURE.md**: Added binary-armhf directories to structure examples
- **COMPONENT-STRUCTURE.md**: Updated directory trees and Release file examples

### Workflow Updates
- **update-repo.yml**: 
  - Create binary-armhf directories in all distributions
  - Generate Packages files via `dpkg-scanpackages -a armhf`
  - Update Release files to list "Architectures: arm64 armhf all"
  
- **remove-package.yml**:
  - Add armhf to architecture choices
  - Include armhf in metadata generation loop
  - Update Release file architectures

### Script Updates  
- **generate-index.py**:
  - Add 'armhf' to SUPPORTED_ARCHITECTURES
  - Set preference order: arm64 (2) > armhf (1) > all (0)

## Impact

✅ **Eliminates user errors**: APT will no longer show warnings on armhf systems
✅ **Supports architecture-independent packages**: Packages marked as "all" will install correctly on armhf
✅ **Future-proof**: Infrastructure ready if armhf-specific packages are built later
✅ **Minimal overhead**: Empty binary-armhf/Packages files add ~2KB per distribution
✅ **Backward compatible**: Existing arm64 and all packages continue to work unchanged

## Implementation Notes

- Even without armhf-specific packages, generating empty Packages files satisfies APT
- armhf packages will only appear if source repositories build them
- 32-bit Raspberry Pi OS uses armhf, 64-bit uses arm64
- Changes are mechanical: adding armhf alongside every arm64 reference

## Testing

After merging and workflow run:
1. Verify all distributions have binary-armhf directories
2. Check Release files list "Architectures: arm64 armhf all"
3. Test on 32-bit Raspberry Pi OS system (armhf):
   - `apt update` should succeed without warnings
   - Architecture-independent packages should be installable

## Files Changed (6)

- `docs/SPEC.md`
- `docs/ARCHITECTURE.md`
- `docs/COMPONENT-STRUCTURE.md`
- `.github/workflows/update-repo.yml`
- `.github/workflows/remove-package.yml`
- `scripts/generate-index.py`