### PR TITLE
fix: update responsive design test for external CSS

### DIFF
--- a/scripts/test_generate_index.py
+++ b/scripts/test_generate_index.py
@@ -269,11 +269,12 @@ class TestMainIndex:
         assert 'TEST12345' in html
 
     def test_main_index_responsive_design(self, all_distributions):
-        """Main index should have responsive design styles."""
+        """Main index should have responsive design via external stylesheet."""
         html = render_main_index(all_distributions, 'ABC123')
-        # Should have CSS styles and responsive elements
-        assert '<style>' in html
-        assert 'media' in html or 'responsive' in html.lower()
+        # Should link to external stylesheet (CSS extracted to styles.css)
+        assert '<link rel="stylesheet" href="styles.css">' in html
+        # Should have viewport meta tag for responsive design
+        assert 'viewport' in html
 
 
 class TestMultiPageGeneration:


### PR DESCRIPTION
## Issue

CI tests are failing on main branch after merging PR #59 (workflow run #275).

**Failure:** `test_main_index_responsive_design` is checking for inline `<style>` tags

**Root Cause:** PR #59 extracted CSS to external `styles.css` file, but one test wasn't updated

## Fix

Update the test to check for the new external stylesheet approach:
- ✅ Check for `<link rel="stylesheet" href="styles.css">` instead of `<style>`  
- ✅ Check for `viewport` meta tag (responsive design indicator)

## Testing

This is a test-only change - no production code modified.

**Before:** Test checks for inline CSS (`<style>` tag)
**After:** Test checks for external CSS link

## Related

- Fixes CI failure from workflow run #275
- Follows up on PR #59 (multi-page distribution layout)
- Aligns test with CSS extraction implementation