### PR TITLE
feat(index): show all components with collapsible groups

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -513,10 +513,20 @@ jobs:
           done
           components=$(echo "$components" | xargs)
 
-          # Validate we have at least one component
+          # Default to main component if no packages found (ensures distribution appears in index)
           if [ -z "$components" ]; then
-            echo "⚠️  Warning: No components found for $dist (skipping Release file)"
-            return 0
+            echo "ℹ️  No packages in $dist, creating empty main component"
+            components="main"
+            # Ensure empty Packages files exist so the distribution is valid
+            mkdir -p "$dist_path/main/binary-arm64"
+            mkdir -p "$dist_path/main/binary-armhf"
+            mkdir -p "$dist_path/main/binary-all"
+            touch "$dist_path/main/binary-arm64/Packages"
+            touch "$dist_path/main/binary-armhf/Packages"
+            touch "$dist_path/main/binary-all/Packages"
+            gzip -kf "$dist_path/main/binary-arm64/Packages"
+            gzip -kf "$dist_path/main/binary-armhf/Packages"
+            gzip -kf "$dist_path/main/binary-all/Packages"
           fi
 
           # Determine suite and description based on distribution pattern


### PR DESCRIPTION
## Summary

- Ensure all 6 distributions appear in the index (including `unstable` and `bookworm-unstable`) by creating Release files even for empty distributions
- Scan and display all components (`main`, `hatlabs`) instead of only `main`
- Display packages in collapsible groups by component using HTML5 `<details>/<summary>` elements
- Update installation commands to list all available components dynamically

## Changes

### Workflow: `.github/workflows/update-repo.yml`
- Modified `build_release()` to always create Release files for empty distributions
- When no packages exist, creates empty Packages files with `main` component as placeholder

### Index Generator: `scripts/generate_index.py`
- Added `component` field to `Package` dataclass
- `scan_distributions()` now discovers all components in each distribution
- Added collapsible component section CSS (pure CSS, no JavaScript)
- Updated rendering to show packages in expandable groups: "Main Packages (N)" and "Hat Labs Products (N)"
- Installation commands now show all available components (e.g., `main hatlabs`)

## Test plan

- [x] Verified Python syntax with `py_compile`
- [x] Tested locally with mock repository structure
- [x] Verified collapsible component groups render correctly
- [x] Verified empty distributions show placeholder message
- [ ] CI tests pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)