### PR TITLE
fix(workflow): handle distro=any in targeted mode

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -584,9 +584,34 @@ jobs:
 
         # Determine which distributions to build
         if [ "$MODE" = "targeted" ]; then
-          echo "=== Targeted Mode: Updating $TARGET_DIST only ==="
-          build_component "$TARGET_DIST" "$COMPONENT"
-          build_release "$TARGET_DIST"
+          DISTRO="${{ steps.payload.outputs.distro }}"
+
+          if [ "$DISTRO" = "any" ]; then
+            # For distro=any, packages are routed to all distro-specific pools
+            # We need to build all {distro}-{channel} distributions
+            echo "=== Targeted Mode: Updating all distributions for distro=any ==="
+
+            # Use same SUPPORTED_DISTROS as routing-functions.sh
+            SUPPORTED_DISTROS="bookworm trixie forky"
+
+            for distro in $SUPPORTED_DISTROS; do
+              dist="${distro}-${CHANNEL}"
+              build_component "$dist" "$COMPONENT"
+              build_release "$dist"
+            done
+
+            # Also build legacy {channel}/main for backward compatibility
+            # (route_package copies distro=any+component=hatlabs to {channel}/main)
+            if [ "$COMPONENT" = "hatlabs" ]; then
+              build_component "$CHANNEL" "main"
+              build_release "$CHANNEL"
+            fi
+          else
+            # Specific distro - build only that distribution
+            echo "=== Targeted Mode: Updating $TARGET_DIST only ==="
+            build_component "$TARGET_DIST" "$COMPONENT"
+            build_release "$TARGET_DIST"
+          fi
         else
           echo "=== Full Rebuild Mode ==="
           echo "Building metadata for all distributions"


### PR DESCRIPTION
## Summary

Fix targeted mode to properly handle `distro=any` by expanding to all supported distributions.

## Problem

When `distro=any`, `route_package()` correctly routes packages to all distro-specific pools:
- `pool/bookworm-unstable/hatlabs/`
- `pool/trixie-unstable/hatlabs/`
- `pool/forky-unstable/hatlabs/`
- `pool/unstable/main/` (legacy)

But targeted mode was only building `pool/unstable/hatlabs/`, which doesn't exist because packages are in the distro-specific paths.

## Solution

In targeted mode, when `distro=any`:
1. Expand to all supported distributions (`bookworm`, `trixie`, `forky`)
2. Build each `{distro}-{channel}/{component}` distribution
3. Handle legacy `{channel}/main` routing for `hatlabs` component

## Conformance

This fix aligns with `docs/COMPONENT-STRUCTURE.md`:
- "Distro expansion is applied (distro=any → all distributions)"
- "Routes packages to `pool/{distro}-{channel}/{component}/`"
- "Legacy routing is applied for Hat Labs packages"

## Test plan

- [x] All existing tests pass (`test-routing-logic.sh`, `test-workflow-integration.sh`)
- [ ] CI passes
- [ ] Test with actual `distro=any` package deployment (halpi2-rust-daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)