### PR TITLE
fix: remove forky from SUPPORTED_DISTROS

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -592,7 +592,7 @@ jobs:
             echo "=== Targeted Mode: Updating all distributions for distro=any ==="
 
             # Use same SUPPORTED_DISTROS as routing-functions.sh
-            SUPPORTED_DISTROS="bookworm trixie forky"
+            SUPPORTED_DISTROS="bookworm trixie"
 
             for distro in $SUPPORTED_DISTROS; do
               dist="${distro}-${CHANNEL}"

--- a/scripts/routing-functions.sh
+++ b/scripts/routing-functions.sh
@@ -5,7 +5,7 @@
 # List of supported distributions (easily extensible for future distros)
 # Note: This list includes only actual distributions, not "any" (which is an alias)
 # See suffix-parsing-functions.sh for VALID_DISTROS which includes "any" for validation
-SUPPORTED_DISTROS=("bookworm" "trixie" "forky")
+SUPPORTED_DISTROS=("bookworm" "trixie")
 
 # route_package - Route a package to appropriate pools based on metadata
 #

--- a/scripts/test-routing-logic.sh
+++ b/scripts/test-routing-logic.sh
@@ -131,7 +131,7 @@ EOF
 # ============================================================================
 # Test 1: Route distro=any, component=hatlabs (legacy routing)
 # ============================================================================
-test_case "Route distro=any, component=hatlabs to 4 locations"
+test_case "Route distro=any, component=hatlabs to 3 locations"
 
 mkdir -p "$TEST_DIR/packages"
 mkdir -p "$TEST_DIR/apt-repo"
@@ -149,12 +149,10 @@ assert_file_exists "$TEST_DIR/apt-repo/pool/bookworm-stable/hatlabs/halpi2-daemo
   "Package routed to bookworm-stable/hatlabs"
 assert_file_exists "$TEST_DIR/apt-repo/pool/trixie-stable/hatlabs/halpi2-daemon_1.0.0-1_all.deb" \
   "Package routed to trixie-stable/hatlabs"
-assert_file_exists "$TEST_DIR/apt-repo/pool/forky-stable/hatlabs/halpi2-daemon_1.0.0-1_all.deb" \
-  "Package routed to forky-stable/hatlabs"
 
 # Count total copies
 count=$(count_files "**/halpi2-daemon_1.0.0-1_all.deb")
-assert_equals "4" "$count" "Package copied to exactly 4 locations"
+assert_equals "3" "$count" "Package copied to exactly 3 locations"
 
 # ============================================================================
 # Test 2: Route distro=trixie, component=main (single location)
@@ -177,9 +175,9 @@ count=$(count_files "**/signalk_2.17.2-1_all.deb")
 assert_equals "1" "$count" "Package copied to exactly 1 location"
 
 # ============================================================================
-# Test 3: Route distro=any, component=main (3 locations, no legacy)
+# Test 3: Route distro=any, component=main (2 locations, no legacy)
 # ============================================================================
-test_case "Route distro=any, component=main to 3 locations (no legacy)"
+test_case "Route distro=any, component=main to 2 locations (no legacy)"
 
 rm -rf "$TEST_DIR/apt-repo"
 mkdir -p "$TEST_DIR/apt-repo"
@@ -192,13 +190,11 @@ assert_file_exists "$TEST_DIR/apt-repo/pool/bookworm-stable/main/runtipi_1.0-1_a
   "Package routed to bookworm-stable/main"
 assert_file_exists "$TEST_DIR/apt-repo/pool/trixie-stable/main/runtipi_1.0-1_all.deb" \
   "Package routed to trixie-stable/main"
-assert_file_exists "$TEST_DIR/apt-repo/pool/forky-stable/main/runtipi_1.0-1_all.deb" \
-  "Package routed to forky-stable/main"
 assert_file_not_exists "$TEST_DIR/apt-repo/pool/stable/main/runtipi_1.0-1_all.deb" \
   "Package NOT routed to legacy stable/main"
 
 count=$(count_files "**/runtipi_1.0-1_all.deb")
-assert_equals "3" "$count" "Package copied to exactly 3 locations"
+assert_equals "2" "$count" "Package copied to exactly 2 locations"
 
 # ============================================================================
 # Test 4: Route unstable channel (pre-release)
@@ -235,7 +231,7 @@ assert_file_exists "$TEST_DIR/apt-repo/pool/trixie-unstable/hatlabs/halpi2-firmw
   "Package routed to trixie-unstable/hatlabs"
 
 count=$(count_files "**/halpi2-firmware_2.0-1_all.deb")
-assert_equals "4" "$count" "Package copied to 4 locations (1 legacy + 3 distro-specific)"
+assert_equals "3" "$count" "Package copied to 3 locations (1 legacy + 2 distro-specific)"
 
 # ============================================================================
 # Test 6: Missing metadata file should fail
@@ -309,17 +305,17 @@ route_package "packages/pkg1_1.0-1_all.deb" "stable" "$TEST_DIR"
 route_package "packages/pkg2_2.0-1_all.deb" "stable" "$TEST_DIR"
 route_package "packages/pkg3_3.0-1_all.deb" "stable" "$TEST_DIR"
 
-# pkg1: 4 locations (legacy + 3 distro-specific)
+# pkg1: 3 locations (legacy + 2 distro-specific)
 pkg1_count=$(count_files "**/pkg1_1.0-1_all.deb")
-assert_equals "4" "$pkg1_count" "pkg1 (any/hatlabs) copied to 4 locations"
+assert_equals "3" "$pkg1_count" "pkg1 (any/hatlabs) copied to 3 locations"
 
 # pkg2: 1 location (trixie-specific)
 pkg2_count=$(count_files "**/pkg2_2.0-1_all.deb")
 assert_equals "1" "$pkg2_count" "pkg2 (trixie/main) copied to 1 location"
 
-# pkg3: 3 locations (no legacy for non-hatlabs)
+# pkg3: 2 locations (no legacy for non-hatlabs)
 pkg3_count=$(count_files "**/pkg3_3.0-1_all.deb")
-assert_equals "3" "$pkg3_count" "pkg3 (any/main) copied to 3 locations"
+assert_equals "2" "$pkg3_count" "pkg3 (any/main) copied to 2 locations"
 
 # ============================================================================
 # Test 10: Invalid channel validation
@@ -363,7 +359,6 @@ expected_dirs=(
   "apt-repo/pool/stable/main"
   "apt-repo/pool/bookworm-stable/hatlabs"
   "apt-repo/pool/trixie-stable/hatlabs"
-  "apt-repo/pool/forky-stable/hatlabs"
 )
 
 all_dirs_exist=true

--- a/scripts/test-workflow-integration.sh
+++ b/scripts/test-workflow-integration.sh
@@ -163,7 +163,6 @@ echo "Scenario: halpi2-daemon with distro=any should be in:"
 echo "  - pool/stable/main (legacy)"
 echo "  - pool/bookworm-stable/hatlabs"
 echo "  - pool/trixie-stable/hatlabs"
-echo "  - pool/forky-stable/hatlabs"
 echo ""
 
 route_package "$TEST_DIR/packages/halpi2-daemon_1.0.0-1_all.deb" "stable" "$TEST_DIR"
@@ -176,9 +175,6 @@ assert_file_exists "$TEST_DIR/apt-repo/pool/bookworm-stable/hatlabs/halpi2-daemo
 
 assert_file_exists "$TEST_DIR/apt-repo/pool/trixie-stable/hatlabs/halpi2-daemon_1.0.0-1_all.deb" \
   "halpi2-daemon in trixie-stable/hatlabs"
-
-assert_file_exists "$TEST_DIR/apt-repo/pool/forky-stable/hatlabs/halpi2-daemon_1.0.0-1_all.deb" \
-  "halpi2-daemon in forky-stable/hatlabs"
 
 # ============================================================================
 # Test 3: Component preservation


### PR DESCRIPTION
## Summary

- Remove forky from SUPPORTED_DISTROS in routing logic
- Update workflow's hardcoded SUPPORTED_DISTROS list
- Update tests to expect 2 distros instead of 3 when expanding `distro=any`

## Problem

Four packages ended up in `forky-unstable` distribution unexpectedly:
- halpi2-firmware_3.2.1-a1-1_all.deb
- halpi2-rust-daemon_5.0.0-5_arm64.deb
- halpid-dbgsym_4.0.7-2_arm64.deb
- halpid_4.0.7-2_arm64.deb

## Root Cause

Source repositories (halpi2-rust-daemon, HALPI2-firmware) use `apt-distro: any` in their release workflows. When `distro=any`, the routing logic expands it to ALL `SUPPORTED_DISTROS`, which included forky.

## Solution

Remove forky from `SUPPORTED_DISTROS` since Debian 14 (forky) is not yet ready for production use. Packages can still be explicitly tagged with `distro=forky` for future use - only the automatic expansion is affected.

## Test plan

- [x] All routing tests pass
- [x] All workflow integration tests pass
- [x] All suffix parsing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)