### PR TITLE
fix(workflow): sort pre-releases by created_at to get latest

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -203,7 +203,7 @@ jobs:
             echo "Fetching latest pre-release from $repo..."
             release_info=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/$repo/releases" | \
-              jq '[.[] | select(.prerelease == true)] | .[0]')
+              jq '[.[] | select(.prerelease == true)] | sort_by(.created_at) | reverse | .[0]')
           else
             echo "Fetching release $release_tag from $repo..."
             release_info=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
## Summary

- Fix pre-release selection to use the most recently created release instead of the first one in the API response

## Problem

The GitHub API doesn't return releases in chronological order. When tag names have different numeric lengths (e.g., `v0.1.1+9_pre` vs `v0.1.1+11_pre`), the API returns them in an order where `v0.1.1+9_pre` appears before `v0.1.1+10_pre` and `v0.1.1+11_pre` because lexicographic sorting puts "9" after "10" and "11" (since `'9' > '1'` in string comparison).

This caused the workflow to fetch `v0.1.1+9_pre` (older packages) instead of `v0.1.1+11_pre` (latest packages), resulting in package version regressions in the APT repository.

## Solution

Sort pre-releases by `created_at` descending before selecting the first one:

```diff
- jq '[.[] | select(.prerelease == true)] | .[0]'
+ jq '[.[] | select(.prerelease == true)] | sort_by(.created_at) | reverse | .[0]'
```

## Test plan

- [ ] Verify the fix by checking that after merge, the APT repo update workflow fetches the correct latest pre-release
- [ ] Confirm package versions in apt.hatlabs.fi match the latest GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)