### PR TITLE
fix: add concurrency group to prevent race conditions

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: '0 6 * * *'        # Daily rebuild
 
+# Serialize all APT repo updates to prevent race conditions.
+# Without this, concurrent workflows can overwrite each other's changes.
+concurrency:
+  group: apt-repo-update
+  cancel-in-progress: false
+
 jobs:
   update-apt-repo:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Multiple `package-updated` repository_dispatch events can trigger concurrent workflow runs. Each run:
1. Fetches gh-pages at time T
2. Downloads its package
3. Deploys to gh-pages

If Workflow B fetches before Workflow A finishes deploying, B's deployment overwrites A's changes, causing package loss.

**Evidence**: `halos-homarr-branding` was added but then overwritten by concurrent `halos-metapackages` run (12 seconds apart).

## Solution

Add GitHub Actions `concurrency` group to serialize all APT repo updates:

```yaml
concurrency:
  group: apt-repo-update
  cancel-in-progress: false
```

This ensures:
- Only one workflow runs at a time
- Queued workflows wait for the current one to complete
- No workflows are cancelled (we don't want to lose package updates)

## Test Plan

1. Merge this PR
2. Trigger two package updates in quick succession
3. Verify both packages appear in the apt repo
4. Check GitHub Actions UI shows workflows queuing instead of running concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)